### PR TITLE
fix: Typo in template for update broker lambda

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -130,7 +130,7 @@ Resources:
       Events:
         PutBroker:
           Type: Api
-          Proeprties:
+          Properties:
             Path: /brokers
             Mthod: put
             RestApiId:


### PR DESCRIPTION
**Contains**
- [x] Bugfix

**Details**
- Typo in template for update broker lambda
