### PR TITLE
feat: Refactor create broker to use User UUID from access token

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -211,12 +211,9 @@ components:
       type: object
       required:
         - name
-        - user_id
       properties:
         name:
           type: string
-        user_id:
-          type: number
     BrokerUpdateRequest:
       type: object
       required:
@@ -345,7 +342,6 @@ components:
       summary: Broker request
       value:
         name: "Forex Broker"
-        user_id: 1
     BrokerUpdateRequest:
       summary: Broker update request
       value:

--- a/trades_management/handlers/create_broker.py
+++ b/trades_management/handlers/create_broker.py
@@ -3,18 +3,24 @@ from uuid import uuid4
 from pony.orm import db_session
 from serpens import api
 
-from entities import Broker
+from entities import Broker, User
 from schemas import BrokerSchema
 
 
 @api.handler
 @db_session
 def handle(request: api.Request):
+    user_uuid = request.authorizer.get("user_uuid")
+    user = User.get(uid=user_uuid)
+
+    if not user:
+        return 401, {"error": "Unauthorized"}
+
     try:
         data = BrokerSchema.load(request.body)
     except (TypeError, ValueError) as error:
         return 400, {"error": f"{error}"}
 
-    broker = Broker(uid=uuid4(), name=data.name, user=data.user_id)
+    broker = Broker(uid=uuid4(), name=data.name, user=user)
 
     return 201, {"uid": str(broker.uid)}

--- a/trades_management/schemas.py
+++ b/trades_management/schemas.py
@@ -7,8 +7,7 @@ from serpens.schema import Schema
 @dataclass
 class BrokerSchema(Schema):
     name: str
-    # TODO: temporary adds here user_id. In future associate user to broker through authentication
-    user_id: int
+    user_id: int = None
     uid: str = None
     created_at: datetime = field(default_factory=datetime.utcnow)
     updated_at: datetime = field(default_factory=datetime.utcnow)


### PR DESCRIPTION
**Contains**
- [x] New feature
- [x] Tests

**Details**
- Make user_id not required in Broker schema
- Get user UUID from access token before create a broker
- Adjust swagger.yml removing user_id from create broker request and example