### PR TITLE
fix: Add AWS Apigateway integration to delete account endpoint

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -512,6 +512,11 @@ paths:
               examples:
                 bad_request:
                   $ref: "#/components/examples/InternalServerError"
+      x-amazon-apigateway-integration:
+        passthroughBehavior: when_no_match
+        httpMethod: POST
+        type: aws_proxy
+        uri: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DeleteAccount.Arn}/invocations"
 
 components:
   schemas:


### PR DESCRIPTION
**Contains**
- [x] Bugfix
- [x] Documentation

**Details**
- Add AWS Apigateway integration to delete account endpoint
